### PR TITLE
Fix Flow when passing Store to the Environment

### DIFF
--- a/src/createEnvironment.js
+++ b/src/createEnvironment.js
@@ -29,6 +29,7 @@ type Options = {|
   // enables/disables `RelayNetworkLogger`
   +logger?: boolean,
   +graphiQLPrinter?: (request: { +text: string, ... }, variables: Variables) => string,
+  +store?: Store,
 |};
 
 type NormalizationSplitOperation = {|


### PR DESCRIPTION
Passing store to the Environment is needed for local state hydration.