### PR TITLE
Gitignore: add 'yarn.lock' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+yarn.lock


### PR DESCRIPTION
We currently cannot maintain lock files of our workspaces but this file is being generated when you install dependencies from OSS. This seems to be the only option at his moment.